### PR TITLE
Ldop 189 fix selenium url

### DIFF
--- a/resources/release_note/js/appRN.js
+++ b/resources/release_note/js/appRN.js
@@ -85,11 +85,13 @@
     }
 
     function createUrl(host){
-        if (window.location.host == "localhost") {
-          return "http://"+ host + "." + window.location.host;
-        } else {
-          return "http://"+ host + "." + window.location.host + (window.location.host.indexOf(".xip.io") > -1) ? "" : ".xip.io/";
+        var toReturn = "http://"+ host + "." + window.location.host;
+
+        if (window.location.host != "localhost") {
+                toReturn += (window.location.host.indexOf(".xip.io") > -1) ? "" : ".xip.io/";
         }
+
+        return toReturn;
     }
 
     function getStatusClass(status,node_status){

--- a/resources/release_note/js/appRN.js
+++ b/resources/release_note/js/appRN.js
@@ -86,7 +86,7 @@
 
     function createUrl(host){
         if (window.location.host == "localhost") {
-          return "http://"+ host + "." + window.location.host);
+          return "http://"+ host + "." + window.location.host;
         } else {
           return "http://"+ host + "." + window.location.host + (window.location.host.indexOf(".xip.io") > -1) ? "" : ".xip.io/";
         }


### PR DESCRIPTION
The initial solution that worked for the URL was a return statement with a ternary operator inside of a ternary operator. While correct, it seemed appropriate to expand that into an if-else to improve readability. Simply expanding the double ternary into an if-else broke the code.

The code below is expanded to an if statement and is more readable that the previous double ternary.