### PR TITLE
Changing the column span for large width viewports 

### DIFF
--- a/resources/release_note/dir/component-list.html
+++ b/resources/release_note/dir/component-list.html
@@ -1,6 +1,6 @@
 <div class="services">
   <div class="row">
-    <div class="col-xs-5 col-sm-4 col-md-3 col-lg-2">
+    <div class="col-xs-5 col-sm-4 col-md-3 col-lg-3">
       <h1 class="service-heading"><span>{{linkitem.type}}</span></h1>
     </div>
   </div>


### PR DESCRIPTION
Changing the column span for large width viewports so the heading doesn't wrap when it is not necessary